### PR TITLE
Updated meck version in rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 %%-*- mode: erlang -*-
 {deps, [
-	{meck, "0.7.1", {git, "https://github.com/eproxus/meck.git", {tag, "0.7.1"}}}
+        {meck, "0.8.2", {git, "https://github.com/eproxus/meck.git", {tag, "0.8.2"}}}
        ]}.

--- a/src/xo_auth_fb.erl
+++ b/src/xo_auth_fb.erl
@@ -24,7 +24,7 @@ handle_fb_req(#httpd{method='GET'}=Req) ->
 
                         GraphmeResponse = request_facebook_graphme_info(AccessToken),
                         create_or_update_user(Req, ClientID, ClientSecret, AccessToken, GraphmeResponse)
-                end;
+                end,
             Code -> 
                 handle_fb_code(Req, Code)
         end

--- a/src/xo_auth_fb.erl
+++ b/src/xo_auth_fb.erl
@@ -24,6 +24,7 @@ handle_fb_req(#httpd{method='GET'}=Req) ->
 
                         GraphmeResponse = request_facebook_graphme_info(AccessToken),
                         create_or_update_user(Req, ClientID, ClientSecret, AccessToken, GraphmeResponse);
+                end
             Code -> 
                 handle_fb_code(Req, Code)
         end

--- a/src/xo_auth_fb.erl
+++ b/src/xo_auth_fb.erl
@@ -24,7 +24,7 @@ handle_fb_req(#httpd{method='GET'}=Req) ->
 
                         GraphmeResponse = request_facebook_graphme_info(AccessToken),
                         create_or_update_user(Req, ClientID, ClientSecret, AccessToken, GraphmeResponse)
-                end,
+                end;
             Code -> 
                 handle_fb_code(Req, Code)
         end

--- a/src/xo_auth_fb.erl
+++ b/src/xo_auth_fb.erl
@@ -24,7 +24,7 @@ handle_fb_req(#httpd{method='GET'}=Req) ->
 
                         GraphmeResponse = request_facebook_graphme_info(AccessToken),
                         create_or_update_user(Req, ClientID, ClientSecret, AccessToken, GraphmeResponse);
-                end
+                end;
             Code -> 
                 handle_fb_code(Req, Code)
         end

--- a/src/xo_auth_fb.erl
+++ b/src/xo_auth_fb.erl
@@ -23,7 +23,7 @@ handle_fb_req(#httpd{method='GET'}=Req) ->
                             xo_auth:extract_config_values("fb", ["redirect_uri", "client_id", "client_secret"]),
 
                         GraphmeResponse = request_facebook_graphme_info(AccessToken),
-                        create_or_update_user(Req, ClientID, ClientSecret, AccessToken, GraphmeResponse);
+                        create_or_update_user(Req, ClientID, ClientSecret, AccessToken, GraphmeResponse)
                 end;
             Code -> 
                 handle_fb_code(Req, Code)

--- a/src/xo_auth_fb.erl
+++ b/src/xo_auth_fb.erl
@@ -77,7 +77,7 @@ create_or_update_user(Req, ClientID, ClientSecret, AccessToken, {ok, FacebookUse
 
 request_facebook_graphme_info(AccessToken) ->
     %% Construct the URL to access the graph API's /me page
-    Url="https://graph.facebook.com/me?fields=id,username,name&access_token="++AccessToken,
+    Url="https://graph.facebook.com/me?fields=id,name&access_token="++AccessToken,
     ?LOG_DEBUG("Url=~p",[Url]),
 
     %% Request the page


### PR DESCRIPTION
The old version was causing rebar builds to fail due to a deprecation warning.
