### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ To add Twitter authentication the following entries are required in the xo_auth.
 
 
 **blowfish** The Twitter Authentication module uses Blowfish to encrypt a temporary cookie. Blowfish was chosen over AES
-because the Erlang crypto module in Ubuntu 10.04 doesn't support AES. _key_ is an arbitaty value upto 56 bytes in length, but must also be a multiple of 8 bytes, _ivec_ is an arbitary 64 bit value (8 bytes)
+because the Erlang crypto module in Ubuntu 10.04 doesn't support AES. _key_ is an arbitaty value upto 56 bytes in length, but must also be a multiple of 8 bytes, _ivec_ is an arbitrary 64 bit value (8 bytes)
 
 Username control
 ----------------


### PR DESCRIPTION
@ocastalabs, I've corrected a typographical error in the documentation of the [CouchDB-XO_Auth](https://github.com/ocastalabs/CouchDB-XO_Auth) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
